### PR TITLE
Support all three platforms (windows-latest, macos-latest, linux-latest) using lukka/run-vcpkg@v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,4 +40,9 @@ jobs:
         run: "cmake --build build"
 
       - name: "Run"
+        if: "contains( matrix.os, 'windows')"
+        run: "build/Debug/vcpkg-example.exe"
+
+      - name: "Run"
+        if: "!contains( matrix.os, 'windows')"
         run: "build/vcpkg-example"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,8 @@ jobs:
     runs-on: "ubuntu-18.04"
     steps:
       - uses: "actions/checkout@v2"
-        submodules: true
+        with:
+          submodules: true
 
       - name: Restore from cache and install vcpkg
         uses: "lukka/run-vcpkg@2"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,14 +14,17 @@ jobs:
     runs-on: "ubuntu-18.04"
     steps:
       - uses: "actions/checkout@v2"
-      - id: "get-vcpkg"
-        uses: "strega-nil/get-vcpkg@trunk"
-      - name: "Cache dependencies"
-        uses: "actions/cache@v1"
+        submodules: true
+
+      - name: Restore from cache and install vcpkg
+        uses: "lukka/run-vcpkg@2"
         with:
-          path: "${{ steps.get-vcpkg.outputs.vcpkg-root }}/archives"
-          key: "vcpkg-dependencies"
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+          appendedCacheKey: '${{ hashFiles("vcpkg.json") }}'
+          setupOnly: true
+
       - name: "Configure"
-        run: "cmake -B build -S . -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_TOOLCHAIN_FILE=${{ steps.get-vcpkg.outputs.vcpkg-root }}/scripts/buildsystems/vcpkg.cmake"
+        run: "cmake -B build -S . -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
+
       - name: "Build"
         run: "cmake --build build"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,8 +24,13 @@ jobs:
         uses: "lukka/run-vcpkg@v2"
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          appendedCacheKey: ${{ hashFiles('vcpkg.json') }}
           setupOnly: true
+
+      - name: "Cache vcpkg_modules"
+        uses: "actions/cache@v1"
+        with:
+          path: vcpkg_modules
+          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
 
       - name: "Configure"
         run: "cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            bin: Debug/vcpkg-example.exe
+          - os: ubuntu-latest
+            bin: vcpkg-example
+          - os: macos-latest
+            bin: vcpkg-example
     steps:
       - uses: "actions/checkout@v2"
         with:
@@ -30,7 +37,9 @@ jobs:
         uses: "actions/cache@v1"
         with:
           path: vcpkg_modules
-          key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          key: ${{ matrix.os }}-modules-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-modules-
 
       - name: "Configure"
         run: |
@@ -40,9 +49,5 @@ jobs:
         run: "cmake --build build"
 
       - name: "Run"
-        if: "contains( matrix.os, 'windows')"
-        run: "build/Debug/vcpkg-example.exe"
-
-      - name: "Run"
-        if: "!contains( matrix.os, 'windows')"
-        run: "build/vcpkg-example"
+        run: |
+          build/${{ matrix.bin }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,8 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
 
       - name: "Configure"
-        run: "cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
+        run: |
+          cmake -B build -S . "-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
       - name: "Build"
         run: "cmake --build build"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
           setupOnly: true
 
-      - name: "Cache vcpkg_modules"
+      - name: Cache vcpkg_modules
         uses: "actions/cache@v1"
         with:
           path: vcpkg_modules
@@ -41,13 +41,13 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-modules-
 
-      - name: "Configure"
+      - name: Configure and build dependencies
         run: |
           cmake -B build -S . "-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
-      - name: "Build"
+      - name: Build
         run: "cmake --build build"
 
-      - name: "Run"
+      - name: Run
         run: |
           build/${{ matrix.bin }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,12 @@ on:
       - trunk
 
 jobs:
-  build-linux:
-    name: "Build on Linux"
-    runs-on: "ubuntu-18.04"
+  job:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: "actions/checkout@v2"
         with:
@@ -25,7 +28,10 @@ jobs:
           setupOnly: true
 
       - name: "Configure"
-        run: "cmake -B build -S . -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
+        run: "cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
 
       - name: "Build"
         run: "cmake --build build"
+
+      - name: "Run"
+        run: "build/vcpkg-example"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: "lukka/run-vcpkg@2"
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          appendedCacheKey: '${{ hashFiles("vcpkg.json") }}'
+          appendedCacheKey: ${{ hashFiles('vcpkg.json') }}
           setupOnly: true
 
       - name: "Configure"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
 
       - name: Restore from cache and install vcpkg
-        uses: "lukka/run-vcpkg@2"
+        uses: "lukka/run-vcpkg@v2"
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
           appendedCacheKey: ${{ hashFiles('vcpkg.json') }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/ras0219/vcpkg
+	branch = manifest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = https://github.com/ras0219/vcpkg
+	url = https://github.com/strega-nil/vcpkg
 	branch = manifest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 
 project(vcpkg-example CXX)
 
+vcpkg_install_packages()
+
 add_executable(vcpkg-example src/main.cxx)
 
 find_package(fmt CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,9 @@ cmake_minimum_required(VERSION 3.14)
 
 project(vcpkg-example CXX)
 
-set(A ${VCPKG_TARGET_TRIPLET})
-set(VCPKG_TARGET_TRIPLET ${VCPKG_TARGET_TRIPLET} --debug)
-vcpkg_install_packages()
-set(VCPKG_TARGET_TRIPLET ${A})
-
 add_executable(vcpkg-example src/main.cxx)
+
+vcpkg_install_packages()
 
 find_package(fmt CONFIG REQUIRED)
 find_package(cppitertools CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(vcpkg-example CXX)
 
 add_executable(vcpkg-example src/main.cxx)
 
-vcpkg_install_packages()
-
 find_package(fmt CONFIG REQUIRED)
 find_package(cppitertools CONFIG REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.14)
 
 project(vcpkg-example CXX)
 
+set(A ${VCPKG_TARGET_TRIPLET})
+set(VCPKG_TARGET_TRIPLET ${VCPKG_TARGET_TRIPLET} --debug)
 vcpkg_install_packages()
+set(VCPKG_TARGET_TRIPLET ${A})
 
 add_executable(vcpkg-example src/main.cxx)
 


### PR DESCRIPTION
This PR also adds vcpkg as a submodule so the precise version can be pinned. A nice advantage of lukka's run-vcpkg is that it will cache the vcpkg binary so it doesn't need to be rebuilt each CI run (but will be rebuilt on submodule change).

If you merge this, you probably want to modify the submodule to point at https://github.com/strega-nil/vcpkg/tree/manifest -- I was unable to use that branch because it is missing https://github.com/microsoft/vcpkg/pull/10973

See an example successful run (with full caching) at https://github.com/ras0219/vcpkg-example/actions/runs/86374911